### PR TITLE
Cowboy WS accepts iodata, so byte_size won't work unless we flatten

### DIFF
--- a/src/cow_ws.erl
+++ b/src/cow_ws.erl
@@ -580,7 +580,7 @@ masked_frame({binary, Payload}, _) ->
 	[<< 1:1, 0:3, 2:4, 1:1, Len/bits >>, MaskKeyBin, mask(iolist_to_binary(Payload), MaskKey, <<>>)].
 
 payload_length(Payload) ->
-	case byte_size(Payload) of
+	case iolist_size(Payload) of
 		N when N =< 125 -> << N:7 >>;
 		N when N =< 16#ffff -> << 126:7, N:16 >>;
 		N when N =< 16#7fffffffffffffff -> << 127:7, N:64 >>


### PR DESCRIPTION
Not sure if your preferred solution is to flatten somewhere else and keep byte_size - either way I crash if I sent iolists in a { reply, IoList, Req, State } websocket handler in cowboy (Docs say that it accepts iodata)

This is *a* fix, there are many others like it but this one is mine (etc).

