### PR TITLE
crash when payload is iodata

### DIFF
--- a/src/cow_ws.erl
+++ b/src/cow_ws.erl
@@ -580,7 +580,7 @@ masked_frame({binary, Payload}, _) ->
 	[<< 1:1, 0:3, 2:4, 1:1, Len/bits >>, MaskKeyBin, mask(iolist_to_binary(Payload), MaskKey, <<>>)].
 
 payload_length(Payload) ->
-	case byte_size(Payload) of
+	case iolist_size(Payload) of
 		N when N =< 125 -> << N:7 >>;
 		N when N =< 16#ffff -> << 126:7, N:16 >>;
 		N when N =< 16#7fffffffffffffff -> << 127:7, N:64 >>


### PR DESCRIPTION
11:58:51.731 [error] cowboy_websocket:websocket_send Frame: {text,[123,[34,"eval",34],58,[34,<<"window.top.location = '';">>,34],125]}, extension:#{}
11:58:51.731 [error] Error in process <0.450.0> on node 'o2o@127.0.0.1' with exit value: {badarg,[{erlang,byte_size,[[123,[34,"eval",34],58,[34,<<25 bytes>>,34],125]],[]},{cow_ws,payload_length,1,[{file,"/home/mihawk/NAGA-WEB/naga_admin/deps/cowlib/src/cow_ws.erl"},{line,585}]},{cow_ws,frame,2,[{file,"/home/mihawk/NAGA-WEB/naga_admin/deps/cowlib/src... 


11:58:51.731 [error] Ranch listener http_naga_admin_listener had connection process started with cowboy_protocol:start_link/4 at <0.450.0> exit with reason: {badarg,[{erlang,byte_size,[[123,[34,"eval",34],58,[34,<<"window.top.location = '';">>,34],125]],[]},{cow_ws,payload_length,1,[{file,"/home/mihawk/NAGA-WEB/test/deps/cowlib/src/cow_ws.erl"},{line,585}]},{cow_ws,frame,2,[{file,"/home/mihawk/NAGA-WEB/naga_admin/deps/cowlib/src/cow_ws.erl"},{line,526}]},{cowboy_websocket,websocket_send,2,[{file,"deps/cowboy/src/cowboy_websocket.erl"},{line,367}]},{cowboy_websocket,handler_call,7,[{file,"deps/cowboy/src/cowboy_websocket.erl"},{line,340}]},{cowboy_protocol,resume,6,[{file,"/home/mihawk/NAGA-WEB/naga_admin/deps/cowboy/src/cowboy_protocol.erl"},{line,486}]}]}