### PR TITLE
Fix handling of default values in cookie options

### DIFF
--- a/src/cow_cookie.erl
+++ b/src/cow_cookie.erl
@@ -197,10 +197,12 @@ setcookie(Name, Value, Opts) ->
 	end,
 	SecureBin = case lists:keyfind(secure, 1, Opts) of
 		false -> <<>>;
+		{_, false} -> <<>>;
 		{_, true} -> <<"; Secure">>
 	end,
 	HttpOnlyBin = case lists:keyfind(http_only, 1, Opts) of
 		false -> <<>>;
+		{_, false} -> <<>>;
 		{_, true} -> <<"; HttpOnly">>
 	end,
 	[Name, <<"=">>, Value, <<"; Version=1">>,
@@ -217,6 +219,12 @@ setcookie_test_() ->
 		{<<"Customer">>, <<"WILE_E_COYOTE">>,
 			[{path, <<"/acme">>}],
 			<<"Customer=WILE_E_COYOTE; Version=1; Path=/acme">>},
+		{<<"Customer">>, <<"WILE_E_COYOTE">>,
+			[{secure, true}],
+			<<"Customer=WILE_E_COYOTE; Version=1; Secure">>},
+		{<<"Customer">>, <<"WILE_E_COYOTE">>,
+			[{secure, false}, {http_only, false}],
+			<<"Customer=WILE_E_COYOTE; Version=1">>},
 		{<<"Customer">>, <<"WILE_E_COYOTE">>,
 			[{path, <<"/acme">>}, {badoption, <<"negatory">>}],
 			<<"Customer=WILE_E_COYOTE; Version=1; Path=/acme">>}


### PR DESCRIPTION
Previously, an error would be raised when explicitly passing a default value for either `http_only` or `secure` option.

This is a fix for ninenines/cowboy#829. It differs with #20 in that it forces option values to be booleans, as specified in the documentation. The solution from #20 would, for example, fall back `{secure, tru}` to a false value, but such a typo should probably cause an exception.

Also some tests are included.