### PR TITLE
Add support for HTTP 451 (RFC 7725)

### DIFF
--- a/src/cow_http.erl
+++ b/src/cow_http.erl
@@ -321,6 +321,7 @@ status(426) -> <<"426 Upgrade Required">>;
 status(428) -> <<"428 Precondition Required">>;
 status(429) -> <<"429 Too Many Requests">>;
 status(431) -> <<"431 Request Header Fields Too Large">>;
+status(451) -> <<"451 Unavailable For Legal Reasons">>;
 status(500) -> <<"500 Internal Server Error">>;
 status(501) -> <<"501 Not Implemented">>;
 status(502) -> <<"502 Bad Gateway">>;


### PR DESCRIPTION
I noticed that this code seems to be missing from cowboy (originally found by me on cowboy 1.1.x, see ninenines/cowboy#1131).

See [rfc7725 section 3](https://tools.ietf.org/html/rfc7725#section-3).