### PR TITLE
force extension of filename into lower char

### DIFF
--- a/src/cow_mimetypes.erl
+++ b/src/cow_mimetypes.erl
@@ -24,8 +24,8 @@ all(Path) ->
 	case filename:extension(Path) of
 		<<>> -> {<<"application">>, <<"octet-stream">>, []};
 		<< $., Ext/binary >> -> 
-			Ext0 = << << (char_to_lower(C)) >> || << C >> <= Ext >>,
-			all_ext(Ext0)
+			LowercaseExt = string:lowercase(Ext),
+			all_ext(LowercaseExt)
 	end.
 
 %% @doc Return the mimetype for a Web related file by looking at its extension.
@@ -35,39 +35,11 @@ web(Path) ->
 	case filename:extension(Path) of
 		<<>> -> {<<"application">>, <<"octet-stream">>, []};
 		<< $., Ext/binary >> -> 
-			Ext0 = << << (char_to_lower(C)) >> || << C >> <= Ext >>,
-			web_ext(Ext0)
+			LowercaseExt = string:lowercase(Ext),
+			web_ext(LowercaseExt)
 	end.
 
 %% Internal.
--spec char_to_lower(char()) -> char().
-char_to_lower($A) -> $a;
-char_to_lower($B) -> $b;
-char_to_lower($C) -> $c;
-char_to_lower($D) -> $d;
-char_to_lower($E) -> $e;
-char_to_lower($F) -> $f;
-char_to_lower($G) -> $g;
-char_to_lower($H) -> $h;
-char_to_lower($I) -> $i;
-char_to_lower($J) -> $j;
-char_to_lower($K) -> $k;
-char_to_lower($L) -> $l;
-char_to_lower($M) -> $m;
-char_to_lower($N) -> $n;
-char_to_lower($O) -> $o;
-char_to_lower($P) -> $p;
-char_to_lower($Q) -> $q;
-char_to_lower($R) -> $r;
-char_to_lower($S) -> $s;
-char_to_lower($T) -> $t;
-char_to_lower($U) -> $u;
-char_to_lower($V) -> $v;
-char_to_lower($W) -> $w;
-char_to_lower($X) -> $x;
-char_to_lower($Y) -> $y;
-char_to_lower($Z) -> $z;
-char_to_lower(Ch) -> Ch.
 
 %% GENERATED
 all_ext(<<"123">>) -> {<<"application">>, <<"vnd.lotus-1-2-3">>, []};

--- a/src/cow_mimetypes.erl
+++ b/src/cow_mimetypes.erl
@@ -24,7 +24,7 @@ all(Path) ->
 	case filename:extension(Path) of
 		<<>> -> {<<"application">>, <<"octet-stream">>, []};
 		<< $., Ext/binary >> -> 
-			LowercaseExt = string:lowercase(Ext),
+			LowercaseExt = lowercase(Ext),
 			all_ext(LowercaseExt)
 	end.
 
@@ -35,11 +35,46 @@ web(Path) ->
 	case filename:extension(Path) of
 		<<>> -> {<<"application">>, <<"octet-stream">>, []};
 		<< $., Ext/binary >> -> 
-			LowercaseExt = string:lowercase(Ext),
+			LowercaseExt = lowercase(Ext),
 			web_ext(LowercaseExt)
 	end.
 
 %% Internal.
+lowercase(Ext)->
+	OTPRelease = erlang:list_to_integer(erlang:system_info(otp_release)),
+	if 
+		OTPRelease >= 20 -> string:lowercase(Ext);
+		true -> << << (char_to_lower(C)) >> || << C >> <= Ext >>
+	end.
+
+-spec char_to_lower(char()) -> char().
+char_to_lower($A) -> $a;
+char_to_lower($B) -> $b;
+char_to_lower($C) -> $c;
+char_to_lower($D) -> $d;
+char_to_lower($E) -> $e;
+char_to_lower($F) -> $f;
+char_to_lower($G) -> $g;
+char_to_lower($H) -> $h;
+char_to_lower($I) -> $i;
+char_to_lower($J) -> $j;
+char_to_lower($K) -> $k;
+char_to_lower($L) -> $l;
+char_to_lower($M) -> $m;
+char_to_lower($N) -> $n;
+char_to_lower($O) -> $o;
+char_to_lower($P) -> $p;
+char_to_lower($Q) -> $q;
+char_to_lower($R) -> $r;
+char_to_lower($S) -> $s;
+char_to_lower($T) -> $t;
+char_to_lower($U) -> $u;
+char_to_lower($V) -> $v;
+char_to_lower($W) -> $w;
+char_to_lower($X) -> $x;
+char_to_lower($Y) -> $y;
+char_to_lower($Z) -> $z;
+char_to_lower(Ch) -> Ch.
 
 %% GENERATED
 all_ext(<<"123">>) -> {<<"application">>, <<"vnd.lotus-1-2-3">>, []};

--- a/src/cow_mimetypes.erl
+++ b/src/cow_mimetypes.erl
@@ -23,9 +23,7 @@
 all(Path) ->
 	case filename:extension(Path) of
 		<<>> -> {<<"application">>, <<"octet-stream">>, []};
-		<< $., Ext/binary >> -> 
-			LowercaseExt = string:lowercase(Ext),
-			all_ext(LowercaseExt)
+		<< $., Ext/binary >> -> all_ext(string:lowercase(Ext))
 	end.
 
 %% @doc Return the mimetype for a Web related file by looking at its extension.
@@ -34,9 +32,7 @@ all(Path) ->
 web(Path) ->
 	case filename:extension(Path) of
 		<<>> -> {<<"application">>, <<"octet-stream">>, []};
-		<< $., Ext/binary >> -> 
-			LowercaseExt = string:lowercase(Ext),
-			web_ext(LowercaseExt)
+		<< $., Ext/binary >> -> web_ext(string:lowercase(Ext))
 	end.
 
 %% Internal.

--- a/src/cow_mimetypes.erl
+++ b/src/cow_mimetypes.erl
@@ -23,7 +23,9 @@
 all(Path) ->
 	case filename:extension(Path) of
 		<<>> -> {<<"application">>, <<"octet-stream">>, []};
-		<< $., Ext/binary >> -> all_ext(Ext)
+		<< $., Ext/binary >> -> 
+			Ext0 = << << (char_to_lower(C)) >> || << C >> <= Ext >>,
+			all_ext(Ext0)
 	end.
 
 %% @doc Return the mimetype for a Web related file by looking at its extension.
@@ -32,10 +34,40 @@ all(Path) ->
 web(Path) ->
 	case filename:extension(Path) of
 		<<>> -> {<<"application">>, <<"octet-stream">>, []};
-		<< $., Ext/binary >> -> web_ext(Ext)
+		<< $., Ext/binary >> -> 
+			Ext0 = << << (char_to_lower(C)) >> || << C >> <= Ext >>,
+			web_ext(Ext0)
 	end.
 
 %% Internal.
+-spec char_to_lower(char()) -> char().
+char_to_lower($A) -> $a;
+char_to_lower($B) -> $b;
+char_to_lower($C) -> $c;
+char_to_lower($D) -> $d;
+char_to_lower($E) -> $e;
+char_to_lower($F) -> $f;
+char_to_lower($G) -> $g;
+char_to_lower($H) -> $h;
+char_to_lower($I) -> $i;
+char_to_lower($J) -> $j;
+char_to_lower($K) -> $k;
+char_to_lower($L) -> $l;
+char_to_lower($M) -> $m;
+char_to_lower($N) -> $n;
+char_to_lower($O) -> $o;
+char_to_lower($P) -> $p;
+char_to_lower($Q) -> $q;
+char_to_lower($R) -> $r;
+char_to_lower($S) -> $s;
+char_to_lower($T) -> $t;
+char_to_lower($U) -> $u;
+char_to_lower($V) -> $v;
+char_to_lower($W) -> $w;
+char_to_lower($X) -> $x;
+char_to_lower($Y) -> $y;
+char_to_lower($Z) -> $z;
+char_to_lower(Ch) -> Ch.
 
 %% GENERATED
 all_ext(<<"123">>) -> {<<"application">>, <<"vnd.lotus-1-2-3">>, []};

--- a/src/cow_mimetypes.erl
+++ b/src/cow_mimetypes.erl
@@ -24,7 +24,7 @@ all(Path) ->
 	case filename:extension(Path) of
 		<<>> -> {<<"application">>, <<"octet-stream">>, []};
 		<< $., Ext/binary >> -> 
-			LowercaseExt = lowercase(Ext),
+			LowercaseExt = string:lowercase(Ext),
 			all_ext(LowercaseExt)
 	end.
 
@@ -35,46 +35,11 @@ web(Path) ->
 	case filename:extension(Path) of
 		<<>> -> {<<"application">>, <<"octet-stream">>, []};
 		<< $., Ext/binary >> -> 
-			LowercaseExt = lowercase(Ext),
+			LowercaseExt = string:lowercase(Ext),
 			web_ext(LowercaseExt)
 	end.
 
 %% Internal.
-lowercase(Ext)->
-	OTPRelease = erlang:list_to_integer(erlang:system_info(otp_release)),
-	if 
-		OTPRelease >= 20 -> string:lowercase(Ext);
-		true -> << << (char_to_lower(C)) >> || << C >> <= Ext >>
-	end.
-
--spec char_to_lower(char()) -> char().
-char_to_lower($A) -> $a;
-char_to_lower($B) -> $b;
-char_to_lower($C) -> $c;
-char_to_lower($D) -> $d;
-char_to_lower($E) -> $e;
-char_to_lower($F) -> $f;
-char_to_lower($G) -> $g;
-char_to_lower($H) -> $h;
-char_to_lower($I) -> $i;
-char_to_lower($J) -> $j;
-char_to_lower($K) -> $k;
-char_to_lower($L) -> $l;
-char_to_lower($M) -> $m;
-char_to_lower($N) -> $n;
-char_to_lower($O) -> $o;
-char_to_lower($P) -> $p;
-char_to_lower($Q) -> $q;
-char_to_lower($R) -> $r;
-char_to_lower($S) -> $s;
-char_to_lower($T) -> $t;
-char_to_lower($U) -> $u;
-char_to_lower($V) -> $v;
-char_to_lower($W) -> $w;
-char_to_lower($X) -> $x;
-char_to_lower($Y) -> $y;
-char_to_lower($Z) -> $z;
-char_to_lower(Ch) -> Ch.
 
 %% GENERATED
 all_ext(<<"123">>) -> {<<"application">>, <<"vnd.lotus-1-2-3">>, []};

--- a/src/cow_mimetypes.erl.src
+++ b/src/cow_mimetypes.erl.src
@@ -24,7 +24,7 @@ all(Path) ->
 	case filename:extension(Path) of
 		<<>> -> {<<"application">>, <<"octet-stream">>, []};
 		<< $., Ext/binary >> -> 
-			LowercaseExt = string:lowercase(Ext),
+			LowercaseExt = lowercase(Ext),
 			all_ext(LowercaseExt)
 	end.
 
@@ -35,11 +35,46 @@ web(Path) ->
 	case filename:extension(Path) of
 		<<>> -> {<<"application">>, <<"octet-stream">>, []};
 		<< $., Ext/binary >> -> 
-			LowercaseExt = string:lowercase(Ext),
+			LowercaseExt = lowercase(Ext),
 			web_ext(LowercaseExt)
 	end.
 
 %% Internal.
+lowercase(Ext)->
+	OTPRelease = erlang:list_to_integer(erlang:system_info(otp_release)),
+	if 
+		OTPRelease >= 20 -> string:lowercase(Ext);
+		true -> << << (char_to_lower(C)) >> || << C >> <= Ext >>
+	end.
+
+-spec char_to_lower(char()) -> char().
+char_to_lower($A) -> $a;
+char_to_lower($B) -> $b;
+char_to_lower($C) -> $c;
+char_to_lower($D) -> $d;
+char_to_lower($E) -> $e;
+char_to_lower($F) -> $f;
+char_to_lower($G) -> $g;
+char_to_lower($H) -> $h;
+char_to_lower($I) -> $i;
+char_to_lower($J) -> $j;
+char_to_lower($K) -> $k;
+char_to_lower($L) -> $l;
+char_to_lower($M) -> $m;
+char_to_lower($N) -> $n;
+char_to_lower($O) -> $o;
+char_to_lower($P) -> $p;
+char_to_lower($Q) -> $q;
+char_to_lower($R) -> $r;
+char_to_lower($S) -> $s;
+char_to_lower($T) -> $t;
+char_to_lower($U) -> $u;
+char_to_lower($V) -> $v;
+char_to_lower($W) -> $w;
+char_to_lower($X) -> $x;
+char_to_lower($Y) -> $y;
+char_to_lower($Z) -> $z;
+char_to_lower(Ch) -> Ch.
 
 %% GENERATED
 all_ext(_) -> {<<"application">>, <<"octet-stream">>, []}.

--- a/src/cow_mimetypes.erl.src
+++ b/src/cow_mimetypes.erl.src
@@ -24,8 +24,8 @@ all(Path) ->
 	case filename:extension(Path) of
 		<<>> -> {<<"application">>, <<"octet-stream">>, []};
 		<< $., Ext/binary >> -> 
-			Ext0 = << << (char_to_lower(C)) >> || << C >> <= Ext >>,
-			all_ext(Ext0)
+			LowercaseExt = string:lowercase(Ext),
+			all_ext(LowercaseExt)
 	end.
 
 %% @doc Return the mimetype for a Web related file by looking at its extension.
@@ -35,40 +35,11 @@ web(Path) ->
 	case filename:extension(Path) of
 		<<>> -> {<<"application">>, <<"octet-stream">>, []};
 		<< $., Ext/binary >> -> 
-			Ext0 = << << (char_to_lower(C)) >> || << C >> <= Ext >>,
-			web_ext(Ext0)
+			LowercaseExt = string:lowercase(Ext),
+			web_ext(LowercaseExt)
 	end.
 
 %% Internal.
-
--spec char_to_lower(char()) -> char().
-char_to_lower($A) -> $a;
-char_to_lower($B) -> $b;
-char_to_lower($C) -> $c;
-char_to_lower($D) -> $d;
-char_to_lower($E) -> $e;
-char_to_lower($F) -> $f;
-char_to_lower($G) -> $g;
-char_to_lower($H) -> $h;
-char_to_lower($I) -> $i;
-char_to_lower($J) -> $j;
-char_to_lower($K) -> $k;
-char_to_lower($L) -> $l;
-char_to_lower($M) -> $m;
-char_to_lower($N) -> $n;
-char_to_lower($O) -> $o;
-char_to_lower($P) -> $p;
-char_to_lower($Q) -> $q;
-char_to_lower($R) -> $r;
-char_to_lower($S) -> $s;
-char_to_lower($T) -> $t;
-char_to_lower($U) -> $u;
-char_to_lower($V) -> $v;
-char_to_lower($W) -> $w;
-char_to_lower($X) -> $x;
-char_to_lower($Y) -> $y;
-char_to_lower($Z) -> $z;
-char_to_lower(Ch) -> Ch.
 
 %% GENERATED
 all_ext(_) -> {<<"application">>, <<"octet-stream">>, []}.

--- a/src/cow_mimetypes.erl.src
+++ b/src/cow_mimetypes.erl.src
@@ -23,7 +23,9 @@
 all(Path) ->
 	case filename:extension(Path) of
 		<<>> -> {<<"application">>, <<"octet-stream">>, []};
-		<< $., Ext/binary >> -> all_ext(Ext)
+		<< $., Ext/binary >> -> 
+			Ext0 = << << (char_to_lower(C)) >> || << C >> <= Ext >>,
+			all_ext(Ext0)
 	end.
 
 %% @doc Return the mimetype for a Web related file by looking at its extension.
@@ -32,10 +34,41 @@ all(Path) ->
 web(Path) ->
 	case filename:extension(Path) of
 		<<>> -> {<<"application">>, <<"octet-stream">>, []};
-		<< $., Ext/binary >> -> web_ext(Ext)
+		<< $., Ext/binary >> -> 
+			Ext0 = << << (char_to_lower(C)) >> || << C >> <= Ext >>,
+			web_ext(Ext0)
 	end.
 
 %% Internal.
+
+-spec char_to_lower(char()) -> char().
+char_to_lower($A) -> $a;
+char_to_lower($B) -> $b;
+char_to_lower($C) -> $c;
+char_to_lower($D) -> $d;
+char_to_lower($E) -> $e;
+char_to_lower($F) -> $f;
+char_to_lower($G) -> $g;
+char_to_lower($H) -> $h;
+char_to_lower($I) -> $i;
+char_to_lower($J) -> $j;
+char_to_lower($K) -> $k;
+char_to_lower($L) -> $l;
+char_to_lower($M) -> $m;
+char_to_lower($N) -> $n;
+char_to_lower($O) -> $o;
+char_to_lower($P) -> $p;
+char_to_lower($Q) -> $q;
+char_to_lower($R) -> $r;
+char_to_lower($S) -> $s;
+char_to_lower($T) -> $t;
+char_to_lower($U) -> $u;
+char_to_lower($V) -> $v;
+char_to_lower($W) -> $w;
+char_to_lower($X) -> $x;
+char_to_lower($Y) -> $y;
+char_to_lower($Z) -> $z;
+char_to_lower(Ch) -> Ch.
 
 %% GENERATED
 all_ext(_) -> {<<"application">>, <<"octet-stream">>, []}.

--- a/src/cow_mimetypes.erl.src
+++ b/src/cow_mimetypes.erl.src
@@ -24,7 +24,7 @@ all(Path) ->
 	case filename:extension(Path) of
 		<<>> -> {<<"application">>, <<"octet-stream">>, []};
 		<< $., Ext/binary >> -> 
-			LowercaseExt = lowercase(Ext),
+			LowercaseExt = string:lowercase(Ext),
 			all_ext(LowercaseExt)
 	end.
 
@@ -35,46 +35,11 @@ web(Path) ->
 	case filename:extension(Path) of
 		<<>> -> {<<"application">>, <<"octet-stream">>, []};
 		<< $., Ext/binary >> -> 
-			LowercaseExt = lowercase(Ext),
+			LowercaseExt = string:lowercase(Ext),
 			web_ext(LowercaseExt)
 	end.
 
 %% Internal.
-lowercase(Ext)->
-	OTPRelease = erlang:list_to_integer(erlang:system_info(otp_release)),
-	if 
-		OTPRelease >= 20 -> string:lowercase(Ext);
-		true -> << << (char_to_lower(C)) >> || << C >> <= Ext >>
-	end.
-
--spec char_to_lower(char()) -> char().
-char_to_lower($A) -> $a;
-char_to_lower($B) -> $b;
-char_to_lower($C) -> $c;
-char_to_lower($D) -> $d;
-char_to_lower($E) -> $e;
-char_to_lower($F) -> $f;
-char_to_lower($G) -> $g;
-char_to_lower($H) -> $h;
-char_to_lower($I) -> $i;
-char_to_lower($J) -> $j;
-char_to_lower($K) -> $k;
-char_to_lower($L) -> $l;
-char_to_lower($M) -> $m;
-char_to_lower($N) -> $n;
-char_to_lower($O) -> $o;
-char_to_lower($P) -> $p;
-char_to_lower($Q) -> $q;
-char_to_lower($R) -> $r;
-char_to_lower($S) -> $s;
-char_to_lower($T) -> $t;
-char_to_lower($U) -> $u;
-char_to_lower($V) -> $v;
-char_to_lower($W) -> $w;
-char_to_lower($X) -> $x;
-char_to_lower($Y) -> $y;
-char_to_lower($Z) -> $z;
-char_to_lower(Ch) -> Ch.
 
 %% GENERATED
 all_ext(_) -> {<<"application">>, <<"octet-stream">>, []}.

--- a/src/cow_mimetypes.erl.src
+++ b/src/cow_mimetypes.erl.src
@@ -23,9 +23,7 @@
 all(Path) ->
 	case filename:extension(Path) of
 		<<>> -> {<<"application">>, <<"octet-stream">>, []};
-		<< $., Ext/binary >> -> 
-			LowercaseExt = string:lowercase(Ext),
-			all_ext(LowercaseExt)
+		<< $., Ext/binary >> -> all_ext(string:lowercase(Ext))
 	end.
 
 %% @doc Return the mimetype for a Web related file by looking at its extension.
@@ -34,9 +32,7 @@ all(Path) ->
 web(Path) ->
 	case filename:extension(Path) of
 		<<>> -> {<<"application">>, <<"octet-stream">>, []};
-		<< $., Ext/binary >> -> 
-			LowercaseExt = string:lowercase(Ext),
-			web_ext(LowercaseExt)
+		<< $., Ext/binary >> -> web_ext(string:lowercase(Ext)) 
 	end.
 
 %% Internal.


### PR DESCRIPTION
Dear author.
I use `cow_mimetypes` to detect mimetypes, but sometime the extension of filename in upper char on filesystem.
So I modify `cow_mimetypes`, force extension of filename into lower char.
