### PR TITLE
:authority is not required by spec

### DIFF
--- a/src/cow_http2_machine.erl
+++ b/src/cow_http2_machine.erl
@@ -551,7 +551,7 @@ headers_pseudo_headers(Frame, State=#http2_machine{local_settings=LocalSettings}
 			headers_malformed(Frame, State,
 				'CONNECT requests only use the :method and :authority pseudo-headers. (RFC7540 8.3)');
 		%% Other requests.
-		{ok, PseudoHeaders=#{method := _, scheme := _, authority := _, path := _}, Headers} ->
+		{ok, PseudoHeaders=#{method := _, scheme := _, path := _}, Headers} ->
 			headers_regular_headers(Frame, State, Type, Stream, PseudoHeaders, Headers);
 		{ok, _, _} ->
 			headers_malformed(Frame, State,


### PR DESCRIPTION
If I understand the spec [RFC 7540](https://tools.ietf.org/html/rfc7540), `:authority` is not required

```
All HTTP/2 requests MUST include exactly one valid value for the
   ":method", ":scheme", and ":path" pseudo-header fields, unless it is
   a CONNECT request (Section 8.3).  An HTTP request that omits
   mandatory pseudo-header fields is malformed (Section 8.1.2.6).
```