### PR TITLE
Support "208 Already Reported"

### DIFF
--- a/src/cow_http.erl
+++ b/src/cow_http.erl
@@ -372,6 +372,7 @@ status(204) -> <<"204 No Content">>;
 status(205) -> <<"205 Reset Content">>;
 status(206) -> <<"206 Partial Content">>;
 status(207) -> <<"207 Multi-Status">>;
+status(208) -> <<"208 Already Reported">>;
 status(226) -> <<"226 IM Used">>;
 status(300) -> <<"300 Multiple Choices">>;
 status(301) -> <<"301 Moved Permanently">>;


### PR DESCRIPTION
This PR aims to allow developers to use the _integer shorthand_ for status code 208, for example in `cowboy_req:reply/3`.

The status code is defined in [RFC 5842 §7.1](https://tools.ietf.org/html/rfc5842#section-7.1).