### PR TITLE
fix: Implement support for case-insensitive Basic header

### DIFF
--- a/src/cow_http_hd.erl
+++ b/src/cow_http_hd.erl
@@ -888,7 +888,10 @@ horse_parse_allow() ->
 	| {bearer, binary()}
 	| {digest, [{binary(), binary()}]}.
 %% @todo The token is case-insensitive. https://tools.ietf.org/html/rfc7235#section-2.1
-parse_authorization(<<"Basic ", R/bits >>) ->
+parse_authorization(<<B, A, S, I, C, " ", R/bits >>)
+		when ((B =:= $B) or (B =:= $b)), ((A =:= $A) or (A =:= $a)),
+			((S =:= $S) or (S =:= $s)), ((I =:= $I) or (I =:= $i)),
+			((C =:= $C) or (C =:= $c)) ->
 	auth_basic(base64:decode(R), <<>>);
 parse_authorization(<<"Bearer ", R/bits >>) when R =/= <<>> ->
 	validate_auth_bearer(R),
@@ -944,6 +947,7 @@ auth_digest_list_sep(<< C, R/bits >>, Acc) when ?IS_WS(C) -> auth_digest_list_se
 parse_authorization_test_() ->
 	Tests = [
 		{<<"Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==">>, {basic, <<"Aladdin">>, <<"open sesame">>}},
+		{<<"bAsIc QWxhZGRpbjpvcGVuIHNlc2FtZQ==">>, {basic, <<"Aladdin">>, <<"open sesame">>}},
 		{<<"Bearer mF_9.B5f-4.1JqM">>, {bearer, <<"mF_9.B5f-4.1JqM">>}},
 		{<<"Digest username=\"Mufasa\","
 				"realm=\"testrealm@host.com\","

--- a/src/cow_http_hd.erl
+++ b/src/cow_http_hd.erl
@@ -893,10 +893,17 @@ parse_authorization(<<B, A, S, I, C, " ", R/bits >>)
 			((S =:= $S) or (S =:= $s)), ((I =:= $I) or (I =:= $i)),
 			((C =:= $C) or (C =:= $c)) ->
 	auth_basic(base64:decode(R), <<>>);
-parse_authorization(<<"Bearer ", R/bits >>) when R =/= <<>> ->
+parse_authorization(<<B, E1, A, R1, E2, R2, " ", R/bits >>)
+		when (R =/= <<>>), ((B =:= $B) or (B =:= $b)),
+			((E1 =:= $E) or (E1 =:= $e)), ((A =:= $A) or (A =:= $a)),
+			((R1 =:= $R) or (R1 =:= $r)), ((E2 =:= $E) or (E2 =:= $e)),
+			((R2 =:= $R) or (R2 =:= $r)) ->
 	validate_auth_bearer(R),
 	{bearer, R};
-parse_authorization(<<"Digest ", R/bits >>) ->
+parse_authorization(<<D, I, G, E, S, T, " ", R/bits >>)
+		when ((D =:= $D) or (D =:= $d)), ((I =:= $I) or (I =:= $i)),
+			((G =:= $G) or (G =:= $g)), ((E =:= $E) or (E =:= $e)),
+			((S =:= $S) or (S =:= $s)), ((T =:= $T) or (T =:= $t)) ->
 	{digest, nonempty(auth_digest_list(R, []))}.
 
 auth_basic(<< $:, Password/bits >>, UserID) -> {basic, UserID, Password};
@@ -949,6 +956,7 @@ parse_authorization_test_() ->
 		{<<"Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==">>, {basic, <<"Aladdin">>, <<"open sesame">>}},
 		{<<"bAsIc QWxhZGRpbjpvcGVuIHNlc2FtZQ==">>, {basic, <<"Aladdin">>, <<"open sesame">>}},
 		{<<"Bearer mF_9.B5f-4.1JqM">>, {bearer, <<"mF_9.B5f-4.1JqM">>}},
+		{<<"bEaRer mF_9.B5f-4.1JqM">>, {bearer, <<"mF_9.B5f-4.1JqM">>}},
 		{<<"Digest username=\"Mufasa\","
 				"realm=\"testrealm@host.com\","
 				"nonce=\"dcd98b7102dd2f0e8b11d0f600bfb0c093\","


### PR DESCRIPTION
This change implements case-insensitive parsing of Basic Authorization
header such that `Basic` is accepted as well as all combinations of
cases, i.e. `bAsIc`, `basic`, etc.