### PR TITLE
Make HPACK encode respect new configured max size

### DIFF
--- a/src/cow_hpack.erl
+++ b/src/cow_hpack.erl
@@ -1433,8 +1433,8 @@ table_resize([Entry = {EntrySize, _}|Tail], MaxSize, Size, Acc) ->
 
 table_update_size(0, State) ->
 	State#state{size=0, max_size=0, dyn_table=[]};
-table_update_size(MaxSize, State=#state{max_size=CurrentMaxSize})
-		when CurrentMaxSize =< MaxSize ->
+table_update_size(MaxSize, State=#state{size=CurrentSize})
+		when CurrentSize =< MaxSize ->
 	State#state{max_size=MaxSize};
 table_update_size(MaxSize, State=#state{dyn_table=DynTable}) ->
 	{DynTable2, Size} = table_resize(DynTable, MaxSize, 0, []),


### PR DESCRIPTION
Correction to cow_hpack:encode/2,3 according to RFC 7541, 4.3. Entry
Eviction When Dynamic Table Size Changes.

This change also corrects the handling of inserting entries larger than
the max size, which shall result in an empty table, according to 4.4.
in the same RFC.

Fixes #101, #103.

The test case is taken from a comment by @blaxmirror in #101 and the solution is inspired by those comments as well.