### PR TITLE
'=' to lists exceptions in 'parse_cookie/2' function 'cow_cookie' module

### DIFF
--- a/src/cow_cookie.erl
+++ b/src/cow_cookie.erl
@@ -58,17 +58,13 @@ parse_cookie(<< $,, Rest/binary >>, Acc) ->
 	parse_cookie(Rest, Acc);
 parse_cookie(<< $;, Rest/binary >>, Acc) ->
 	parse_cookie(Rest, Acc);
+parse_cookie(<< $=, Rest/binary >>, Acc) ->
+	parse_cookie(Rest, Acc);
 parse_cookie(Cookie, Acc) ->
 	parse_cookie_name(Cookie, Acc, <<>>).
 
 parse_cookie_name(<<>>, Acc, Name) ->
 	lists:reverse([{<<>>, parse_cookie_trim(Name)}|Acc]);
-parse_cookie_name(<< $=, _/binary >>, _, <<>>) ->
-	error(badarg);
-parse_cookie_name(<< $=, Rest/binary >>, Acc, Name) ->
-	parse_cookie_value(Rest, Acc, Name, <<>>);
-parse_cookie_name(<< $,, _/binary >>, _, _) ->
-	error(badarg);
 parse_cookie_name(<< $;, Rest/binary >>, Acc, Name) ->
 	parse_cookie(Rest, [{<<>>, parse_cookie_trim(Name)}|Acc]);
 parse_cookie_name(<< $\t, _/binary >>, _, _) ->


### PR DESCRIPTION
'=' necessary handle to 'parse_cookie/2' since here:

https://github.com/ninenines/cowlib/blob/master/src/cow_cookie.erl#L66

will be crash if "=" it is name of cookie!