### PR TITLE
ignore unknown authentication parameters in the Basic authentication scheme

### DIFF
--- a/src/cow_http_hd.erl
+++ b/src/cow_http_hd.erl
@@ -3383,16 +3383,9 @@ www_auth_list(<< C, R/bits >>, Acc) when ?IS_WS_COMMA(C) -> www_auth_list(R, Acc
 www_auth_list(<< C, R/bits >>, Acc) when ?IS_TOKEN(C) ->
 	?LOWER(www_auth_scheme, R, Acc, <<>>).
 
-www_auth_basic_before_realm(<< C, R/bits >>, Acc) when ?IS_WS(C) -> www_auth_basic_before_realm(R, Acc);
-www_auth_basic_before_realm(<< "realm=\"", R/bits >>, Acc) -> www_auth_basic(R, Acc, <<>>).
-
-www_auth_basic(<< $", R/bits >>, Acc, Realm) -> www_auth_list_sep(R, [{basic, Realm}|Acc]);
-www_auth_basic(<< $\\, C, R/bits >>, Acc, Realm) when ?IS_VCHAR_OBS(C) -> www_auth_basic(R, Acc, << Realm/binary, C >>);
-www_auth_basic(<< C, R/bits >>, Acc, Realm) when ?IS_VCHAR_OBS(C) -> www_auth_basic(R, Acc, << Realm/binary, C >>).
-
 www_auth_scheme(<< C, R/bits >>, Acc, Scheme) when ?IS_WS(C) ->
 	case Scheme of
-		<<"basic">> -> www_auth_basic_before_realm(R, Acc);
+		<<"basic">> -> www_auth_params_list(R, Acc, basic, []);
 		<<"bearer">> -> www_auth_params_list(R, Acc, bearer, []);
 		<<"digest">> -> www_auth_params_list(R, Acc, digest, []);
 		_ -> www_auth_params_list(R, Acc, Scheme, [])
@@ -3400,12 +3393,15 @@ www_auth_scheme(<< C, R/bits >>, Acc, Scheme) when ?IS_WS(C) ->
 www_auth_scheme(<< C, R/bits >>, Acc, Scheme) when ?IS_TOKEN(C) ->
 	?LOWER(www_auth_scheme, R, Acc, Scheme).
 
-www_auth_list_sep(<<>>, Acc) -> lists:reverse(Acc);
-www_auth_list_sep(<< C, R/bits >>, Acc) when ?IS_WS(C) -> www_auth_list_sep(R, Acc);
-www_auth_list_sep(<< $,, R/bits >>, Acc) -> www_auth_list(R, Acc).
+www_auth_scheme(basic = Scheme, Params) ->
+	%% Ignore other authparams according to RFC-7617
+	{<<"realm">>, Realm} = lists:keyfind(<<"realm">>, 1, Params),
+	{Scheme, Realm};
+www_auth_scheme(Scheme, Params) ->
+	{Scheme, lists:reverse(Params)}.
 
 www_auth_params_list(<<>>, Acc, Scheme, Params) ->
-	lists:reverse([{Scheme, lists:reverse(nonempty(Params))}|Acc]);
+	lists:reverse([www_auth_scheme(Scheme, nonempty(Params))|Acc]);
 www_auth_params_list(<< C, R/bits >>, Acc, Scheme, Params) when ?IS_WS_COMMA(C) ->
 	www_auth_params_list(R, Acc, Scheme, Params);
 www_auth_params_list(<< "algorithm=", C, R/bits >>, Acc, Scheme, Params) when ?IS_TOKEN(C) ->
@@ -3442,7 +3438,7 @@ www_auth_param(<< $=, C, R/bits >>, Acc, Scheme, Params, K) when ?IS_TOKEN(C) ->
 www_auth_param(<< C, R/bits >>, Acc, Scheme, Params, K) when ?IS_TOKEN(C) ->
 	?LOWER(www_auth_param, R, Acc, Scheme, Params, K);
 www_auth_param(R, Acc, Scheme, Params, NewScheme) ->
-	www_auth_scheme(R, [{Scheme, lists:reverse(Params)}|Acc], NewScheme).
+	www_auth_scheme(R, [www_auth_scheme(Scheme, Params)|Acc], NewScheme).
 
 www_auth_token(<< C, R/bits >>, Acc, Scheme, Params, K, V) when ?IS_TOKEN(C) ->
 	www_auth_token(R, Acc, Scheme, Params, K, << V/binary, C >>);
@@ -3457,14 +3453,14 @@ www_auth_quoted(<< C, R/bits >>, Acc, Scheme, Params, K, V) when ?IS_VCHAR_OBS(C
 	www_auth_quoted(R, Acc, Scheme, Params, K, << V/binary, C >>).
 
 www_auth_params_list_sep(<<>>, Acc, Scheme, Params) ->
-	lists:reverse([{Scheme, lists:reverse(Params)}|Acc]);
+	lists:reverse([www_auth_scheme(Scheme, Params)|Acc]);
 www_auth_params_list_sep(<< C, R/bits >>, Acc, Scheme, Params) when ?IS_WS(C) ->
 	www_auth_params_list_sep(R, Acc, Scheme, Params);
 www_auth_params_list_sep(<< $,, R/bits >>, Acc, Scheme, Params) ->
 	www_auth_params_list_after_sep(R, Acc, Scheme, Params).
 
 www_auth_params_list_after_sep(<<>>, Acc, Scheme, Params) ->
-	lists:reverse([{Scheme, lists:reverse(Params)}|Acc]);
+	lists:reverse([www_auth_scheme(Scheme, Params)|Acc]);
 www_auth_params_list_after_sep(<< C, R/bits >>, Acc, Scheme, Params) when ?IS_WS_COMMA(C) ->
 	www_auth_params_list_after_sep(R, Acc, Scheme, Params);
 www_auth_params_list_after_sep(R, Acc, Scheme, Params) ->
@@ -3496,6 +3492,18 @@ parse_www_authenticate_test_() ->
 			]}]},
 		{<<"Basic realm=\"WallyWorld\"">>,
 			[{basic, <<"WallyWorld">>}]},
+		%% From https://www.rfc-editor.org/rfc/rfc7617.html#section-2.1
+		{<<"Basic realm=\"foo\", charset=\"UTF-8\"">>,
+			[{basic, <<"foo">>}]},
+		%% From the wild :)
+		{<<"Basic realm=\"https://123456789012.dkr.ecr.eu-north-1.amazonaws.com/\",service=\"ecr.amazonaws.com\"">>,
+			[{basic, <<"https://123456789012.dkr.ecr.eu-north-1.amazonaws.com/">>}]},
+		{<<"Bearer realm=\"example\", Basic realm=\"foo\", charset=\"UTF-8\"">>,
+			[{bearer, [{<<"realm">>, <<"example">>}]},
+			{basic, <<"foo">>}]},
+		{<<"Basic realm=\"foo\", foo=\"bar\", charset=\"UTF-8\", Bearer realm=\"example\",foo=\"bar\"">>,
+			[{basic, <<"foo">>},
+			{bearer, [{<<"realm">>, <<"example">>}, {<<"foo">>,<<"bar">>}]}]},
 		{<<"Digest realm=\"testrealm@host.com\", qop=\"auth,auth-int\", "
 				"nonce=\"dcd98b7102dd2f0e8b11d0f600bfb0c093\", "
 				"opaque=\"5ccc069c403ebaf9f0171e9517f40e41\"">>,


### PR DESCRIPTION
I received the following `WWW-Authenticate` header (while using gun towards AWS's ECR):
```
Basic realm="https://123456789012.dkr.ecr.eu-north-1.amazonaws.com/",service="ecr.amazonaws.com"
```
which made `cow_http_hd:parse_www_authenticate/1` crash on a function clause. First I thought the header was wrong, but if I understand https://www.rfc-editor.org/rfc/rfc7617.html#section-2 right, it is permitted to include other authentication parameters in the response (although only `charset` has a defined meaning).

I made the attached fix, which basically throws away all authentication parameters other than "realm" for the `Basic` scheme. Perhaps one would like to return the other params, but I don't see a backwards compatible way of doing so (maybe returning `{basic,Realm}` when there are no other parameters and `{basic, Realm, Params}` when there are would be more "future proof" - but also more work for the client...)