### PR TITLE
Ignore client_max_window_bits with missing header

### DIFF
--- a/src/cow_ws.erl
+++ b/src/cow_ws.erl
@@ -133,6 +133,8 @@ negotiate_permessage_deflate1(Params, Extensions, Opts) ->
 			ignore;
 		{#{client_max_window_bits := CB}, _} when CB > ClientMaxWindowBits ->
 			ignore;
+		{Negotiated, _} when not is_map_key(client_max_window_bits_set, Negotiated), ClientMaxWindowBits < 15 ->
+			ignore;
 		{Negotiated, RespParams2} ->
 			%% We add the configured max window bits if necessary.
 			RespParams = case Negotiated of
@@ -165,12 +167,14 @@ negotiate_params([{<<"client_max_window_bits">>, Max}|Tail], Negotiated, RespPar
 		error ->
 			ignore;
 		CB when CB =< CB0 ->
-			negotiate_params(Tail, Negotiated#{client_max_window_bits => CB},
+			negotiate_params(Tail,
+				Negotiated#{client_max_window_bits => CB,
+					client_max_window_bits_set => true},
 				[<<"; client_max_window_bits=">>, Max|RespParams]);
 		%% When the client sends window bits larger than the server wants
 		%% to use, we use what the server defined.
 		_ ->
-			negotiate_params(Tail, Negotiated,
+			negotiate_params(Tail, Negotiated#{client_max_window_bits_set => true},
 				[<<"; client_max_window_bits=">>, integer_to_binary(CB0)|RespParams])
 	end;
 negotiate_params([{<<"server_max_window_bits">>, Max}|Tail], Negotiated, RespParams) ->


### PR DESCRIPTION
When the client does not provide the "client_max_window_bits" option,
the server must reserve the max size.

Currently, if the server provides the option `client_max_window_bits` with something less than 15 and a client does not include the option and uses more than the unknown server value, zlib will fail to inflate the payload.

I'll leave this in draft until I'm able to test it.

Are automatic tests for this functionality expected in `cowboy`?