### PR TITLE
Add a function to check remote HTTP/2 setting MAX_CONCURRENT_STREAMS

### DIFF
--- a/src/cow_http2_machine.erl
+++ b/src/cow_http2_machine.erl
@@ -1658,11 +1658,11 @@ is_remote_concurrency_limit_reached(State=#http2_machine{
 		count_local_streams(State) >= MaxConcurrentStreams.
 
 count_local_streams(#http2_machine{mode=Mode, streams=Streams}) ->
-	lists:foldl(fun(StreamId, Sum) when ?IS_LOCAL(Mode, StreamId) ->
+	maps:fold(fun(StreamId, _Stream, Sum) when ?IS_LOCAL(Mode, StreamId) ->
 			Sum + 1;
-		(_, Sum) ->
+		(_, _, Sum) ->
 			Sum
-	end, 0, maps:keys(Streams)).
+	end, 0, Streams).
 
 %% Query whether the stream was reset recently by the remote endpoint.
 


### PR DESCRIPTION
This is to be used primarily by a client before initiating a new stream
so that it can respect the setting from the server.

I've tested in in a draft patch to gun. Will post a gun PR soon.