### PR TITLE
Fix a compile error on the Erlang/OTP master (since `erlang/otp/pull/6864` was merged)

### DIFF
--- a/src/cow_sse.erl
+++ b/src/cow_sse.erl
@@ -53,7 +53,7 @@ init() ->
 %% @todo Add a function to retrieve the retry value from the state.
 
 -spec parse(binary(), state())
-	-> {event, parsed_event(), State} | {more, State}.
+	-> {event, parsed_event(), state()} | {more, state()}.
 parse(Data0, State=#state{state_name=bom, buffer=Buffer}) ->
 	Data1 = case Buffer of
 		<<>> -> Data0;


### PR DESCRIPTION
`cowlib` contains the following `-spec` that is now invalid on the Erlang/OTP master branch as https://github.com/erlang/otp/pull/6864 was merged.

```erlang
%% src/cow_sse.erl:56:29
-spec parse(binary(), state())                                                                                                                                                                                                                     
         -> {event, parsed_event(), State} | {more, State}.  
```

The compile error is as follows:
```console
$ rebar3 compile
===> Verifying dependencies...
===> Analyzing applications...
===> Compiling cowlib
===> Compiling src/cow_sse.erl failed
src/cow_sse.erl:56:29: type variable 'State' is only used once (is unbound)
```

This PR fixes this error by replacing the unbounded `State` variable with `state()` type.
