### PR TITLE
Export types used in the exported cow_http2:frame() type

### DIFF
--- a/src/cow_http2.erl
+++ b/src/cow_http2.erl
@@ -43,8 +43,13 @@
 -export_type([head_fin/0]).
 
 -type exclusive() :: exclusive | shared.
+-export_type([exclusive/0]).
+
 -type weight() :: 1..256.
+-export_type([weight/0]).
+
 -type settings() :: map().
+-export_type([settings/0]).
 
 -type error() :: no_error
 	| protocol_error


### PR DESCRIPTION
With these types exported, a frame() can be decomposed and all parts can be typed using exported types.