### PR TITLE
Add cow_qpack:init/0 convenience function

### DIFF
--- a/src/cow_qpack.erl
+++ b/src/cow_qpack.erl
@@ -15,6 +15,7 @@
 -module(cow_qpack).
 -dialyzer(no_improper_lists).
 
+-export([init/0]).
 -export([init/1]).
 -export([init/3]).
 
@@ -136,6 +137,11 @@
 -include("cow_hpack_common.hrl").
 
 %% State initialization.
+
+-spec init() -> state().
+
+init() ->
+	init(encoder).
 
 -spec init(decoder | encoder) -> state().
 


### PR DESCRIPTION
## Summary

- Adds `cow_qpack:init/0` function that defaults to encoder role
- Provides simpler initialization when encoder is the most common use case