### PR TITLE
fix: improper handing of cookie creation from key-value pairs 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 PROJECT = cowlib
 PROJECT_DESCRIPTION = Support library for manipulating Web protocols.
-PROJECT_VERSION = 2.16.1
+PROJECT_VERSION = 2.16.2
 
 # Options.
 

--- a/ebin/cowlib.app
+++ b/ebin/cowlib.app
@@ -1,6 +1,6 @@
 {application, 'cowlib', [
 	{description, "Support library for manipulating Web protocols."},
-	{vsn, "2.16.1"},
+	{vsn, "2.16.2"},
 	{modules, ['cow_base64url','cow_capsule','cow_cookie','cow_date','cow_deflate','cow_hpack','cow_http','cow_http1','cow_http2','cow_http2_machine','cow_http3','cow_http3_machine','cow_http_hd','cow_http_struct_hd','cow_http_te','cow_iolists','cow_link','cow_mimetypes','cow_multipart','cow_qpack','cow_qs','cow_sse','cow_uri','cow_uri_template','cow_ws']},
 	{registered, []},
 	{applications, [kernel,stdlib,crypto]},

--- a/src/cow_cookie.erl
+++ b/src/cow_cookie.erl
@@ -318,13 +318,23 @@ parse_set_cookie_test_() ->
 cookie([]) ->
 	[];
 cookie([{<<>>, Value}]) ->
-	[Value];
+	[cookie_value(Value)];
 cookie([{Name, Value}]) ->
-	[Name, $=, Value];
+	[cookie_name(Name), $=, cookie_value(Value)];
 cookie([{<<>>, Value}|Tail]) ->
-	[Value, $;, $\s|cookie(Tail)];
+	[cookie_value(Value), $;, $\s|cookie(Tail)];
 cookie([{Name, Value}|Tail]) ->
-	[Name, $=, Value, $;, $\s|cookie(Tail)].
+	[cookie_name(Name), $=, cookie_value(Value), $;, $\s|cookie(Tail)].
+
+cookie_name(Name) ->
+	nomatch = binary:match(iolist_to_binary(Name), [<<$=>>, <<$,>>, <<$;>>,
+			<<$\s>>, <<$\t>>, <<$\r>>, <<$\n>>, <<$\013>>, <<$\014>>]),
+	Name.
+
+cookie_value(Value) ->
+	nomatch = binary:match(iolist_to_binary(Value), [<<$,>>, <<$;>>,
+			<<$\s>>, <<$\t>>, <<$\r>>, <<$\n>>, <<$\013>>, <<$\014>>]),
+	Value.
 
 -ifdef(TEST).
 cookie_test_() ->
@@ -337,6 +347,35 @@ cookie_test_() ->
 	],
 	[{Res, fun() -> Res = iolist_to_binary(cookie(Cookies)) end}
 		|| {Cookies, Res} <- Tests].
+
+cookie_injection_test_() ->
+	F = fun(Cookies) ->
+		try cookie(Cookies) of
+			_ -> false
+		catch _:_ -> true
+		end
+	end,
+	Tests = [
+		[{<<"name\r\n">>, <<"value">>}],
+		[{<<"name\r">>, <<"value">>}],
+		[{<<"name\n">>, <<"value">>}],
+		[{<<"name=">>, <<"value">>}],
+		[{<<"name;">>, <<"value">>}],
+		[{<<"name,">>, <<"value">>}],
+		[{<<"name ">>, <<"value">>}],
+		[{<<"name\t">>, <<"value">>}],
+		[{<<"name">>, <<"value\r\nInjected: header">>}],
+		[{<<"name">>, <<"value\r">>}],
+		[{<<"name">>, <<"value\n">>}],
+		[{<<"name">>, <<"value;">>}],
+		[{<<"name">>, <<"value,">>}],
+		[{<<"name">>, <<"value ">>}],
+		[{<<"name">>, <<"value\t">>}],
+		[{<<>>, <<"value\r\nInjected: header">>}],
+		[{<<"a">>, <<"b">>}, {<<"c">>, <<"d\r\nSet-Cookie: x">>}]
+	],
+	[{iolist_to_binary(io_lib:format("~p", [C])),
+		fun() -> true = F(C) end} || C <- Tests].
 -endif.
 
 %% Convert a cookie name, value and options to its iodata form.


### PR DESCRIPTION
## Summary

* Fix [GHSA-g2wm-735q-3f56](https://github.com/advisories/GHSA-g2wm-735q-3f56)
* Patch version to 2.16.2

Fixes #152