### PR TITLE
Reject invalid characters in cow_cookie:cookie/1

### DIFF
--- a/doc/src/manual/cow_cookie.cookie.asciidoc
+++ b/doc/src/manual/cow_cookie.cookie.asciidoc
@@ -31,6 +31,7 @@ An iolist with the generated cookie header value.
 
 == Changelog
 
+* *2.16.2*: Reject invalid characters in `Name` and `Value` to prevent injection.
 * *2.9*: Function introduced.
 
 == Examples

--- a/src/cow_cookie.erl
+++ b/src/cow_cookie.erl
@@ -318,13 +318,23 @@ parse_set_cookie_test_() ->
 cookie([]) ->
 	[];
 cookie([{<<>>, Value}]) ->
-	[Value];
+	[cookie_value(Value)];
 cookie([{Name, Value}]) ->
-	[Name, $=, Value];
+	[cookie_name(Name), $=, cookie_value(Value)];
 cookie([{<<>>, Value}|Tail]) ->
-	[Value, $;, $\s|cookie(Tail)];
+	[cookie_value(Value), $;, $\s|cookie(Tail)];
 cookie([{Name, Value}|Tail]) ->
-	[Name, $=, Value, $;, $\s|cookie(Tail)].
+	[cookie_name(Name), $=, cookie_value(Value), $;, $\s|cookie(Tail)].
+
+cookie_name(Name) ->
+	nomatch = binary:match(iolist_to_binary(Name), [<<$=>>, <<$,>>, <<$;>>,
+			<<$\s>>, <<$\t>>, <<$\r>>, <<$\n>>, <<$\013>>, <<$\014>>]),
+	Name.
+
+cookie_value(Value) ->
+	nomatch = binary:match(iolist_to_binary(Value), [<<$,>>, <<$;>>,
+			<<$\s>>, <<$\t>>, <<$\r>>, <<$\n>>, <<$\013>>, <<$\014>>]),
+	Value.
 
 -ifdef(TEST).
 cookie_test_() ->
@@ -333,10 +343,61 @@ cookie_test_() ->
 		{[{<<"a">>, <<"b">>}], <<"a=b">>},
 		{[{<<"a">>, <<"b">>}, {<<"c">>, <<"d">>}], <<"a=b; c=d">>},
 		{[{<<>>, <<"b">>}, {<<"c">>, <<"d">>}], <<"b; c=d">>},
-		{[{<<"a">>, <<"b">>}, {<<>>, <<"d">>}], <<"a=b; d">>}
+		{[{<<"a">>, <<"b">>}, {<<>>, <<"d">>}], <<"a=b; d">>},
+		%% iodata in name/value (not just binary).
+		{[{[<<"a">>, "b"], ["c", <<"d">>]}], <<"ab=cd">>},
+		%% Equal sign is allowed in cookie-value per RFC6265 section 4.2.1.
+		{[{<<"a">>, <<"b=c">>}], <<"a=b=c">>}
 	],
 	[{Res, fun() -> Res = iolist_to_binary(cookie(Cookies)) end}
 		|| {Cookies, Res} <- Tests].
+
+cookie_failures_test_() ->
+	F = fun(Cookies) ->
+		try cookie(Cookies) of
+			_ ->
+				false
+		catch _:_ ->
+			true
+		end
+	end,
+	%% Each rejected character should fail at the name position (except
+	%% $=, which is allowed in cookie-value but not in cookie-name) and
+	%% at the value position.
+	Tests = [
+		%% Name rejects: $=, $,, $;, $\s, $\t, $\r, $\n, $\013, $\014
+		[{<<"Na=me">>, <<"Value">>}],
+		[{<<"Na,me">>, <<"Value">>}],
+		[{<<"Na;me">>, <<"Value">>}],
+		[{<<"Na me">>, <<"Value">>}],
+		[{<<"Na\tme">>, <<"Value">>}],
+		[{<<"Na\rme">>, <<"Value">>}],
+		[{<<"Na\nme">>, <<"Value">>}],
+		[{<<"Na\013me">>, <<"Value">>}],
+		[{<<"Na\014me">>, <<"Value">>}],
+		%% Value rejects: $,, $;, $\s, $\t, $\r, $\n, $\013, $\014
+		[{<<"Name">>, <<"Va,lue">>}],
+		[{<<"Name">>, <<"Va;lue">>}],
+		[{<<"Name">>, <<"Va lue">>}],
+		[{<<"Name">>, <<"Va\tlue">>}],
+		[{<<"Name">>, <<"Va\rlue">>}],
+		[{<<"Name">>, <<"Va\nlue">>}],
+		[{<<"Name">>, <<"Va\013lue">>}],
+		[{<<"Name">>, <<"Va\014lue">>}],
+		%% Classic header-injection payload.
+		[{<<"Name">>, <<"Value\r\nSet-Cookie: evil=1">>}],
+		%% Empty-name variant: invalid value must still be rejected.
+		[{<<>>, <<"Va;lue">>}],
+		%% Rejected pair is not necessarily the first one.
+		[{<<"good">>, <<"ok">>}, {<<"bad;name">>, <<"v">>}],
+		[{<<"good">>, <<"ok">>}, {<<"name">>, <<"bad;value">>}],
+		%% iodata input is also validated.
+		[{[<<"Na">>, ";me"], <<"Value">>}],
+		[{<<"Name">>, [<<"Va">>, ";lue"]}]
+	],
+	[{iolist_to_binary(io_lib:format("~p failure", [Cookies])),
+		fun() -> true = F(Cookies) end}
+		|| Cookies <- Tests].
 -endif.
 
 %% Convert a cookie name, value and options to its iodata form.


### PR DESCRIPTION
## Summary

`cow_cookie:cookie/1` currently emits a Cookie header for any input,
even when the name or value contains separators or control bytes that
break the header syntax. A caller passing user-controlled data to the
encoder (against the documented contract) can produce smuggled cookies
or header-split attacks. This is tracked publicly as
[CVE-2026-43969 / GHSA-g2wm-735q-3f56](https://github.com/advisories/GHSA-g2wm-735q-3f56).

This change applies the same input check `setcookie/3` already performs
to `cookie/1`: validate name and value against the forbidden set
(`=`, `,`, `;`, whitespace, `\t`, `\r`, `\n`, `\013`, `\014`) and fail
loudly via `{badmatch, _}` instead of emitting a malformed/injectable
header.

## Re: the lax-builder policy

I'm aware of the line in `AGENTS.md`:

> Cowlib is typically strict at parsing but lax at building protocol
> output. It is the responsibility of the caller to sanitize the data
> given to Cowlib to build protocol output.

— and of the documentation-only fix in 6ccef1c. So you may want to
decline this on philosophical grounds, which is fair. The argument for
making an exception here is the one already implicit in `setcookie/3`:
when the cost of unsanitized output is HTTP header injection, the
library has historically chosen to fail loudly. This PR just makes
`cookie/1` consistent with `setcookie/3` on that one point. Happy to
close if you'd rather keep the asymmetry.

## Changes

- `src/cow_cookie.erl`: each `cookie/1` clause routes `Name` and
  `Value` through `cookie_name/1` / `cookie_value/1`, which mirror
  the existing `nomatch = binary:match(...)` check in `setcookie/3`.
- Tests: kept all existing happy-path cases; added two more
  (iodata input, `=` allowed in cookie-value); added
  `cookie_failures_test_/0` modeled on `setcookie_failures_test_/0`
  that covers every forbidden character at both name and value
  positions, a header-injection payload, the empty-name variant,
  invalid pair not in head position, and iodata inputs.
- `doc/src/manual/cow_cookie.cookie.asciidoc`: added a single
  changelog line. Left the "expects ... to be safe" wording you
  added in 6ccef1c as-is, since `setcookie.asciidoc` keeps the
  same wording even though `setcookie/3` enforces.

## Test plan

- [x] `cookie_test_/0` (existing + 2 new happy cases): 7/7 pass
- [x] `cookie_failures_test_/0` (new): 23/23 rejections
- [ ] `make eunit` + `make dialyzer` in your CI