### PR TITLE
fix: add C >= 128 guards + fallback to all UTF-8 continuation validators in cow_ws (crash on malformed text frames)

### DIFF
--- a/src/cow_ws.erl
+++ b/src/cow_ws.erl
@@ -692,7 +692,7 @@ validate_s0(<<C,R/bits>>) when C >= 128 ->
 validate_s0(Text) ->
 	validate_ascii(Text).
 
-validate_s2(<<C,R/bits>>) ->
+validate_s2(<<C,R/bits>>) when C >= 128 ->
 	Class = element(C - 127, utf8_class()),
 	case Class of
 		7 -> validate_s0(R);
@@ -700,10 +700,12 @@ validate_s2(<<C,R/bits>>) ->
 		9 -> validate_s0(R);
 		_ -> 1
 	end;
+validate_s2(<<_,_/bits>>) ->
+	1;
 validate_s2(<<>>) ->
 	2.
 
-validate_s3(<<C,R/bits>>) ->
+validate_s3(<<C,R/bits>>) when C >= 128 ->
 	Class = element(C - 127, utf8_class()),
 	case Class of
 		7 -> validate_s2(R);
@@ -711,39 +713,47 @@ validate_s3(<<C,R/bits>>) ->
 		9 -> validate_s2(R);
 		_ -> 1
 	end;
+validate_s3(<<_,_/bits>>) ->
+	1;
 validate_s3(<<>>) ->
 	3.
 
-validate_s4(<<C,R/bits>>) ->
+validate_s4(<<C,R/bits>>) when C >= 128 ->
 	Class = element(C - 127, utf8_class()),
 	case Class of
 		7 -> validate_s2(R);
 		_ -> 1
 	end;
+validate_s4(<<_,_/bits>>) ->
+	1;
 validate_s4(<<>>) ->
 	4.
 
-validate_s5(<<C,R/bits>>) ->
+validate_s5(<<C,R/bits>>) when C >= 128 ->
 	Class = element(C - 127, utf8_class()),
 	case Class of
 		1 -> validate_s2(R);
 		9 -> validate_s2(R);
 		_ -> 1
 	end;
+validate_s5(<<_,_/bits>>) ->
+	1;
 validate_s5(<<>>) ->
 	5.
 
-validate_s6(<<C,R/bits>>) ->
+validate_s6(<<C,R/bits>>) when C >= 128 ->
 	Class = element(C - 127, utf8_class()),
 	case Class of
 		7 -> validate_s3(R);
 		9 -> validate_s3(R);
 		_ -> 1
 	end;
+validate_s6(<<_,_/bits>>) ->
+	1;
 validate_s6(<<>>) ->
 	6.
 
-validate_s7(<<C,R/bits>>) ->
+validate_s7(<<C,R/bits>>) when C >= 128 ->
 	Class = element(C - 127, utf8_class()),
 	case Class of
 		7 -> validate_s3(R);
@@ -751,15 +761,19 @@ validate_s7(<<C,R/bits>>) ->
 		9 -> validate_s3(R);
 		_ -> 1
 	end;
+validate_s7(<<_,_/bits>>) ->
+	1;
 validate_s7(<<>>) ->
 	7.
 
-validate_s8(<<C,R/bits>>) ->
+validate_s8(<<C,R/bits>>) when C >= 128 ->
 	Class = element(C - 127, utf8_class()),
 	case Class of
 		1 -> validate_s3(R);
 		_ -> 1
 	end;
+validate_s8(<<_,_/bits>>) ->
+	1;
 validate_s8(<<>>) ->
 	8.
 


### PR DESCRIPTION
## Summary

WebSocket text/close frames must be valid UTF-8. The state machine in cow_ws:validate_text/2 (and validate_sN helpers) assumed continuation states (s2-s8) would only ever see bytes >= 128.

A low byte (< 128) while in one of those states (e.g. truncated/malformed frame from network or adversarial input) caused element(C-127, utf8_class()) to receive an out-of-range index and crash (badarg; after partial guard also function_clause).

This is the root cause of the crash reported in ninenines/cowlib#158.

## Fix (smallest defensible change)

- Add when C >= 128 guard to the main clause of validate_s2 .. validate_s8 (consistent with validate_s0).
- Add a fallback clause for any other non-empty input in those states: validate_sN(<<_,_/bits>>) -> 1;  (return the 'bad encoding' sentinel).
- The <<>> terminal clauses are unchanged (return the state number for 'more').

Valid UTF-8 paths (ASCII fast path, 2/3/4-byte sequences, fragmented text frames) are unaffected.

## Testing

Local verification (no full erlang.mk TEST_DEPS fetch required):
- erlc compiles the module cleanly (no warnings after anon-var cleanup).
- Exercised the paths via the exported parse_payload/9 (which drives validate_payload -> validate_text for text frames):
  - ASCII and valid multi-byte (e.g. cent 0xC2A2) -> {ok, Payload, 0, <<>>}
  - Partial first-byte + second -> more then {ok}
  - Low ASCII byte while Utf8State=2 (s2) -> {error, badencoding} with zero crash.

This makes the UTF-8 validator robust against the reported class of input.

Fixes ninenines/cowlib#158

---

(Contrib loop: claimed via work claim, investigated, smallest targeted change + manual property-like smoke on the exact crash scenario, self-verified compile+exec, now gating.)