### PR TITLE
Fix HPACK decoding of name indexes 63..190

### DIFF
--- a/src/cow_hpack.erl
+++ b/src/cow_hpack.erl
@@ -171,7 +171,7 @@ dec_lit_index_new_name(Rest, State, Acc, Opts) ->
 dec_lit_index_indexed_name(<<2#111111:6, 0:1, Int:7, Rest/bits>>,
 		State, Acc, Opts) ->
 	Name = table_get_name(63 + Int, State),
-	dec_lit_index(Rest, State, Acc, Name, Opts);
+	dec_lit_index(Rest, State, Acc, Opts, Name);
 dec_lit_index_indexed_name(<<2#111111:6, Rest0/bits>>, State, Acc, Opts) ->
 	{Index, Rest} = dec_big_int(Rest0, 63, 0),
 	Name = table_get_name(Index, State),
@@ -230,6 +230,27 @@ dec_str(<<1:1, Length:7, Rest/bits>>) ->
 %% Test case extracted from h2spec.
 decode_reject_eos_test() ->
 	{'EXIT', _} = (catch decode(<<16#0085f2b24a84ff874951fffffffa7f:120>>)),
+	ok.
+
+%% Literal header field with incremental indexing where the indexed
+%% name lives in the dynamic table at an index that requires the
+%% multi-byte integer form (63..190).
+decode_lit_index_dynamic_name_test() ->
+	%% Fill the dynamic table with two entries:
+	%% x-name-a: v1, then x-name-b: v1.
+	{_, State0} = decode(<<
+		16#4008782d6e616d652d61027631:104,
+		16#4008782d6e616d652d62027631:104 >>),
+	#state{dyn_table=[
+		{42,{<<"x-name-b">>, <<"v1">>}},
+		{42,{<<"x-name-a">>, <<"v1">>}}]} = State0,
+	%% Literal header with incremental indexing, name at index 63.
+	{Headers, State} = decode(<< 16#7f00027632:40 >>, State0),
+	Headers = [{<<"x-name-a">>, <<"v2">>}],
+	#state{dyn_table=[
+		{42,{<<"x-name-a">>, <<"v2">>}},
+		{42,{<<"x-name-b">>, <<"v1">>}},
+		{42,{<<"x-name-a">>, <<"v1">>}}]} = State,
 	ok.
 
 req_decode_test() ->


### PR DESCRIPTION
After having a lot of trouble with upgrading phoenix_storybook and getting rid of some annoying warnings, Claude found this bug. 

----

The dec_lit_index_indexed_name/4 clause handling the one-byte integer continuation (<<2#111111:6, 0:1, Int:7, …>>) passes Name and Opts swapped to dec_lit_index/5 (the sibling clauses pass Opts, Name). Introduced in cb11a4f1.

Decoding a literal header field with incremental indexing whose name references a table entry at index 63–190 then crashes the decoder — the opts map ends up in table_insert/2 where byte_size/1 raises badarg. cow_http2_machine catches it and reports {connection_error, compression_error, ...}, so servers tear down the whole HTTP/2 connection, failing every multiplexed stream.

Browsers hit this quickly in practice: Chrome fills the dynamic table on its first request, so a subsequent request on the same connection referencing a header name at index ≥ 63 kills the connection (ERR_HTTP2_PROTOCOL_ERROR on all in-flight requests). Simple curl testing masks the bug since few enough distinct headers are sent that name indexes stay below 63. Found running cowboy 2.16.0 + cowlib 2.17.0.

Includes a regression test; fails with badarg before the fix, passes after. Full eunit suite passes (3262 tests).