### PR TITLE
Struct headers: reject invalid characters when building strings

### DIFF
--- a/src/cow_http_struct_hd.erl
+++ b/src/cow_http_struct_hd.erl
@@ -499,7 +499,8 @@ exp_div(N) -> 10 * exp_div(N + 1).
 escape_string(<<>>, Acc) -> Acc;
 escape_string(<<$\\,R/bits>>, Acc) -> escape_string(R, <<Acc/binary,$\\,$\\>>);
 escape_string(<<$",R/bits>>, Acc) -> escape_string(R, <<Acc/binary,$\\,$">>);
-escape_string(<<C,R/bits>>, Acc) -> escape_string(R, <<Acc/binary,C>>).
+escape_string(<<C,R/bits>>, Acc) when C >= 16#20, C =< 16#7e ->
+	escape_string(R, <<Acc/binary,C>>).
 
 params(Params) ->
 	[case Param of
@@ -538,5 +539,9 @@ struct_hd_identity_test_() ->
 struct_hd_item_test() ->
 	<<"token">> = iolist_to_binary(item({item, {token, <<"token">>}, []})),
 	?assertError(_, item({item, {token, <<"tok\0en">>}, []})),
+	<<"\"str\"">> = iolist_to_binary(item({item, {string, <<"str">>}, []})),
+	?assertError(_, item({item, {string, <<"str\r\ning">>}, []})),
+	?assertError(_, item({item, {string, <<"str\0ing">>}, []})),
+	?assertError(_, item({item, {string, <<"str", 16#7f, "ing">>}, []})),
 	ok.
 -endif.


### PR DESCRIPTION
`escape_string/2` only escaped `\` and `"`, passing every other byte through verbatim. Per RFC 8941 4.1.1.1 a structured field string may only contain SP and VCHAR (%x20-7E), so bytes such as CR or LF could be emitted unescaped and enable HTTP response splitting.

This restricts the builder to %x20-7E, mirroring what `parse_string/2` already accepts on the way in. Any other byte now crashes, the same way an invalid token does since 1af7790.

Fixes CVE-2026-43966.

`struct_hd_item_test` is extended to cover rejection of CR/LF, NUL and DEL, and that a normal string still builds.
