### PR TITLE
Mark cow_cookie:cookie/1 as unsafe

### DIFF
--- a/src/cow_cookie.erl
+++ b/src/cow_cookie.erl
@@ -19,6 +19,11 @@
 -export([cookie/1]).
 -export([setcookie/3]).
 
+%% The -unsafe attribute is validated starting from OTP-29.
+%% On earlier OTP versions it is treated as a wild attribute.
+-unsafe([{cookie, 1, "the Name and Value must be safe, "
+	"meaning they do not contain invalid characters"}]).
+
 -type cookie_attrs() :: #{
 	expires => calendar:datetime(),
 	max_age => calendar:datetime(),


### PR DESCRIPTION
As suggested in #152, this marks `cow_cookie:cookie/1` with the OTP-29 `-unsafe` attribute, making the input safety expectations documented in the manual machine-readable: `xref`'s `unsafe_function_calls` analysis reports the call sites, whose owners can then validate their input and acknowledge the call with `-ignore_xref`.

Regarding building on older OTP versions: before OTP-29 the attribute is treated as a wild attribute. Verified by compiling with OTP 28.4.1 — compiles clean and the attribute is preserved in `module_info(attributes)`. OTP-29 validates the attribute at compile time (it errors if the function is not exported), so typos cannot creep in.

No behavior change; all eunit tests pass on OTP 29.

If this is the direction you want, the same marker can be extended to `setcookie/3` (for the `domain`/`path` options) and other builders in a follow-up. It may also give the EEF CNA a formal basis to bound the affected range of CVE-2026-43969 at the next release, per their internal-API criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)