### PR TITLE
Struct headers: reject non-VCHAR bytes when building strings (CVE-2026-43966)

### DIFF
--- a/src/cow_http_struct_hd.erl
+++ b/src/cow_http_struct_hd.erl
@@ -499,7 +499,11 @@ exp_div(N) -> 10 * exp_div(N + 1).
 escape_string(<<>>, Acc) -> Acc;
 escape_string(<<$\\,R/bits>>, Acc) -> escape_string(R, <<Acc/binary,$\\,$\\>>);
 escape_string(<<$",R/bits>>, Acc) -> escape_string(R, <<Acc/binary,$\\,$">>);
-escape_string(<<C,R/bits>>, Acc) -> escape_string(R, <<Acc/binary,C>>).
+%% A structured field string may only contain printable ASCII (RFC 8941
+%% sf-string, %x20-7E). Reject any other byte to prevent header injection
+%% (e.g. CR/LF response splitting) when building headers from strings.
+escape_string(<<C,R/bits>>, Acc) when C >= 16#20, C =< 16#7e ->
+	escape_string(R, <<Acc/binary,C>>).
 
 params(Params) ->
 	[case Param of
@@ -538,5 +542,13 @@ struct_hd_identity_test_() ->
 struct_hd_item_test() ->
 	<<"token">> = iolist_to_binary(item({item, {token, <<"token">>}, []})),
 	?assertError(_, item({item, {token, <<"tok\0en">>}, []})),
+	ok.
+
+struct_hd_string_test() ->
+	<<"\"string\"">> = iolist_to_binary(item({item, {string, <<"string">>}, []})),
+	<<"\"\\\"\\\\\"">> = iolist_to_binary(item({item, {string, <<$",$\\>>}, []})),
+	?assertError(_, item({item, {string, <<"bad\r\nstring">>}, []})),
+	?assertError(_, item({item, {string, <<"bad\0string">>}, []})),
+	?assertError(_, item({item, {string, <<"bad\tstring">>}, []})),
 	ok.
 -endif.


### PR DESCRIPTION
When serializing a structured field `{string, String}`, `cow_http_struct_hd:escape_string/2` copied every byte through unchanged apart from `\` and `"`:

```erlang
escape_string(<<C,R/bits>>, Acc) -> escape_string(R, <<Acc/binary,C>>).
```

A caller building a header from an untrusted string could therefore embed control bytes such as CR/LF into the quoted string, splitting the HTTP response (**CVE-2026-43966**, HTTP response splitting via non-VCHAR bytes). This is the string counterpart of the `{token, _}` validation added in `1af7790`.

Per [RFC 8941](https://www.rfc-editor.org/rfc/rfc8941#name-strings) an `sf-string` may only contain printable ASCII (`%x20-7E`). This change guards the fall-through clause so any other byte raises `function_clause` at build time (fail-loud), matching the `ok = validate_token(...)` approach already used for tokens.

### Changes
- Guard `escape_string/2` to accept only `%x20-7E`; other bytes now error instead of being emitted.
- Add `struct_hd_string_test/0` covering a normal string, the `"`/`\` escapes, and rejection of CR/LF, NUL and TAB.

### Verification
- Valid printable strings still round-trip through `item/1` unchanged.
- New test fails on the old code (CR/LF was emitted verbatim) and passes with the guard.
- Clean `erlc` compile, no new warnings.